### PR TITLE
Typo in event-operation.md

### DIFF
--- a/docs/event-operation.md
+++ b/docs/event-operation.md
@@ -12,7 +12,7 @@
 * Short Press “Enter” Moves tri-angle cursor
 * Long Press “Enter” toggles channel mode.
 * Star means “HDZero Only”
-* Sequare means “Analog Only”
+* Square means “Analog Only”
 
 <img src="/eventmedia/image4.png" id="image4">
 


### PR DESCRIPTION
Typo: 
Currently it says `Sequare means “Analog Only”`
I think this was supposed to be Square.